### PR TITLE
Justin Schulz code challenge submission

### DIFF
--- a/lib/flows/machine.ts
+++ b/lib/flows/machine.ts
@@ -20,7 +20,7 @@ export async function init(flow: Flow) {
 }
 
 export async function receiveMessage(
-  member: Member,
+  member: Partial<Member>,
   flow: Flow,
   startIndex: number,
   message: string
@@ -33,7 +33,6 @@ export async function receiveMessage(
       break
     }
     // GetInfo: Save info in message to key in member
-    console.log('getting info: ', message)
     if (action.type === 'getInfo') {
       ;(member[action.key] as any) = message
     }
@@ -43,10 +42,12 @@ export async function receiveMessage(
       })
       if (match) {
         messages.push(match.message)
+      } else {
+        messages.push(`I didn't understand that. ${action.message}`)
+        index--
       }
     }
     index++
   }
-  console.warn({ messages, stopIndex: startIndex + index, member })
   return { messages, stopIndex: startIndex + index, member }
 }

--- a/lib/flows/machine.ts
+++ b/lib/flows/machine.ts
@@ -4,12 +4,9 @@
 // Implements a cursor that advances across a flow definition
 // and processes inputs with actions
 
-import { Flow, Member } from "../models";
+import { Flow, Member } from '../models'
 
-export async function init(
-  member: Member,
-  flow: Flow
-) {
+export async function init(flow: Flow) {
   let stopIndex = 0
   const messages = []
   for (const action of flow.definition) {
@@ -36,11 +33,12 @@ export async function receiveMessage(
       break
     }
     // GetInfo: Save info in message to key in member
+    console.log('getting info: ', message)
     if (action.type === 'getInfo') {
-      (member[action.key] as any) = message
+      ;(member[action.key] as any) = message
     }
     if (action.type === 'multipleChoice') {
-      const match = action.responses.find(r => {
+      const match = action.responses.find((r) => {
         return r.value === message.trim() || r.synonyms.includes(message.trim())
       })
       if (match) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "next": "13.0.4",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "zod": "3.19.1"
       },
       "devDependencies": {
         "@emotion/react": "11.10.5",
@@ -5717,6 +5718,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -9693,6 +9702,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "next": "13.0.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "zod": "3.19.1"
   },
   "devDependencies": {
     "@emotion/react": "11.10.5",

--- a/pages/api/flows/[flowId]/simulate.ts
+++ b/pages/api/flows/[flowId]/simulate.ts
@@ -1,6 +1,19 @@
 import { init, receiveMessage } from '@/lib/flows/machine'
 import { Flow, FLOWS, Member } from '@/lib/models'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { z } from 'zod'
+
+const simulateRequestSchema = z.object({
+  member: z.object({
+    id: z.number(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phoneNumber: z.string().optional(),
+    isSubscribed: z.boolean().optional(),
+  }),
+  message: z.string().optional(),
+  startIndex: z.number(),
+})
 
 // Flow Simulation Endpoint
 // By making a series of requests to this endpoint, please simulate the back-and-forth
@@ -10,23 +23,43 @@ import { NextApiRequest, NextApiResponse } from 'next'
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { flowId } = req.query
   const flow = FLOWS.find((f) => f.id === parseInt(flowId as string, 10))
-  if (!flow) {
-    res.status(404).end()
+  if (typeof flow === 'undefined') {
+    return res.status(404).end()
   }
 
-  const { member, message, startIndex = 0 } = req.body
+  const simulateRequest = simulateRequestSchema.safeParse(req.body)
+  if (!simulateRequest.success) {
+    return res.status(500).end()
+  }
+
+  const { member, message, startIndex = 0 } = simulateRequest.data
 
   // CHALLENGE ZONE:
   // Please do something here to allow simulation of interaction with the flow!
-  // const y = init(?)
-  // const x = receiveMessage(?)
+  let result
 
-  const result = await receiveMessage(
-    member as unknown as Member,
-    flow as Flow,
-    startIndex,
-    message
-  )
+  // The flow begins the conversation
+  if (startIndex === 0 && message === '') {
+    result = await init(flow)
+  } else {
+    // The user has replied to the flow
+    result = await receiveMessage(member as unknown as Member, flow as Flow, startIndex, message)
+    result.messages = filterToNewMessages(result.messages, flow, startIndex)
+  }
+
   console.warn(result)
-  return res.json({ ok: true })
+  return res.json({
+    ok: true,
+    result,
+  })
+}
+
+const filterToNewMessages = (messages: string[], flow: Flow, previousActionIndex: number) => {
+  if (!messages.length) {
+    return messages
+  }
+  const lastMessage = flow.definition[previousActionIndex].message
+
+  const startIndex = messages.indexOf(lastMessage) + 1
+  return messages.slice(startIndex)
 }

--- a/pages/api/flows/[flowId]/simulate.ts
+++ b/pages/api/flows/[flowId]/simulate.ts
@@ -5,13 +5,13 @@ import { z } from 'zod'
 
 const simulateRequestSchema = z.object({
   member: z.object({
-    id: z.number(),
+    id: z.number().optional(),
     name: z.string().optional(),
     email: z.string().optional(),
     phoneNumber: z.string().optional(),
     isSubscribed: z.boolean().optional(),
   }),
-  message: z.string().optional(),
+  message: z.string(),
   startIndex: z.number(),
 })
 
@@ -29,6 +29,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   const simulateRequest = simulateRequestSchema.safeParse(req.body)
   if (!simulateRequest.success) {
+    console.error(simulateRequest.error)
     return res.status(500).end()
   }
 
@@ -43,11 +44,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     result = await init(flow)
   } else {
     // The user has replied to the flow
-    result = await receiveMessage(member as unknown as Member, flow as Flow, startIndex, message)
+    result = await receiveMessage(member, flow as Flow, startIndex, message)
     result.messages = filterToNewMessages(result.messages, flow, startIndex)
   }
 
-  console.warn(result)
   return res.json({
     ok: true,
     result,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,21 @@
+import { Member } from '@/lib/models'
 import Head from 'next/head'
 import React, { useCallback, useEffect } from 'react'
 import { useState } from 'react'
 
 interface SimulateFlowRequestPayload {
   flowId: number
-  member: any
+  member: Partial<Member>
   message: string
   startIndex: number
 }
+
+interface FlowMessage {
+  message: string
+  senderType: SenderType
+}
+
+type SenderType = 'user' | 'flow'
 
 async function simulateFlow({
   flowId,
@@ -21,7 +29,7 @@ async function simulateFlow({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      member,
+      member: member || {},
       message,
       startIndex,
     }),
@@ -31,18 +39,20 @@ async function simulateFlow({
 
 export default function Home() {
   const [flowId, setFlowId] = useState(1)
-
-  // This format provided for convenience. Please change if necessary.
-  const [messages, setMessages] = useState<{ message: string }[]>([])
+  const [member, setMember] = useState<Partial<Member>>({ id: 1 })
+  const [messages, setMessages] = useState<FlowMessage[]>([])
   const [userMessage, setUserMessageText] = useState('')
   const [startIndex, setStartIndex] = useState(0)
 
   const startConversation = useCallback(async () => {
-    const response = await simulateFlow({ flowId, member: { id: 1 }, message: '', startIndex: 0 })
+    const response = await simulateFlow({ flowId, member, message: '', startIndex: 0 })
     const data = await response.json()
 
-    setMessages((data.result.messages as string[]).map((message) => ({ message })))
+    setMessages(
+      (data.result.messages as string[]).map((message) => ({ message, senderType: 'flow' }))
+    )
     setStartIndex(data.result.stopIndex)
+    setMember(data.result.member)
   }, [flowId])
 
   useEffect(() => {
@@ -50,23 +60,30 @@ export default function Home() {
   }, [startConversation])
 
   async function sendMessage() {
-    const optimisticallyUpdatedMessages = [...messages, { message: userMessage }]
+    const optimisticallyUpdatedMessages = [
+      ...messages,
+      { message: userMessage, senderType: 'user' as SenderType },
+    ]
     setMessages(optimisticallyUpdatedMessages)
     setUserMessageText('')
 
     try {
       const response = await simulateFlow({
         flowId,
-        member: { id: 1 },
+        member: member,
         message: userMessage,
         startIndex,
       })
       const data = await response.json()
 
+      setMember(data.result.member)
       setStartIndex(data.result.stopIndex)
       setMessages([
         ...optimisticallyUpdatedMessages,
-        ...(data.result.messages as string[]).map((message) => ({ message })),
+        ...(data.result.messages as string[]).map((message) => ({
+          message,
+          senderType: 'flow' as SenderType,
+        })),
       ])
     } catch (error) {
       console.error(error)
@@ -78,6 +95,33 @@ export default function Home() {
       return
     }
     sendMessage()
+  }
+
+  function renderMessage(message: FlowMessage, memberName: string, i: number) {
+    switch (message.senderType) {
+      case 'flow':
+        return (
+          <div key={i} className="m-1 bg-slate-200" title="Bot">
+            <div className="inline-flex mr-2 ml-2 overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 rounded-full dark:bg-gray-600">
+              <span className="font-medium text-gray-600 dark:text-gray-300">
+                B
+              </span>
+            </div>
+            <span>{message.message}</span>
+          </div>
+        )
+      case 'user':
+        return (
+          <div key={i} className="m-1 bg-sky-200 text-right" title={memberName}>
+            <span>{message.message}</span>
+            <div className="inline-flex ml-2 overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 rounded-full dark:bg-gray-600">
+              <span className="font-medium text-gray-600 dark:text-gray-300">
+                {memberName[0].toUpperCase()}
+              </span>
+            </div>
+          </div>
+        )
+    }
   }
 
   return (
@@ -117,12 +161,8 @@ export default function Home() {
 
           <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-2xl">
             <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-              <div className="border-solid border-2 border-indigo-600 h-64">
-                {messages.map((m, i) => (
-                  <div key={i} className="m-1 bg-slate-200">
-                    {m.message}
-                  </div>
-                ))}
+              <div className="border-solid border-2 border-indigo-600 h-64 overflow-auto">
+                {messages.map((m, i) => renderMessage(m, member?.name || 'Guest', i))}
               </div>
               <div className="border-solid border border-slate-100 my-1">
                 <input


### PR DESCRIPTION
**Description**

When faced with some ambiguities in the challenge, I worked from these inferred specs:
* When a user changes the flow with the drop down, it clears out the conversation to start a fresh flow.
* The init function on the server is called when the page loads or the flow changes. This means the server sends the first messages every time. Personally, I think initializing the flow should be its own controller as opposed to a special case in the simulate controller, but I punted on that for this exercise.
* When the flow is complete, the server will not respond with any more messages
* For multiple choice cases, if the user's answer does not match any of the options, the server will repeat the question until it "understands" the user's input

**Future improvements**

I time boxed my solution, so there are a few nice-to-haves that I intentionally left out. When a new message arrives that causes the chat box to overflow, a scrollbar appears, but the window does not scroll to the new element. This could be fixed with either flex-box, using column reverse or with javascript to scroll to the new message.
The components could be factored a little more nicely, potentially using things like the React context API to control things like user data, with stateless presentational components. However for this toy app, I think it's fine to keep it all in one place for now.